### PR TITLE
import sys, fixes scons NameError

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,6 +1,7 @@
 # -*- Python -*-
 import os
 import distutils.sysconfig
+import sys
 
 def die(msg):
     sys.stderr.write("ERROR "+msg+"\n")


### PR DESCRIPTION
fixes "NameError: global name 'sys' is not defined:"
