### PR TITLE
Fix an inversion of rows and columns in ADDCOLS

### DIFF
--- a/clstm.h
+++ b/clstm.h
@@ -61,7 +61,7 @@ typedef Eigen::MatrixXf Mat;
 inline void ADDCOLS(Mat &m, Vec &v) {
     for (int i = 0; i < COLS(m); i++)
         for (int j = 0; j < ROWS(m); j++)
-            m(i, j) += v(j);
+            m(j, i) += v(j);
 }
 inline void randgauss(Mat &m) {
     std::random_device rd;


### PR DESCRIPTION
When a network is trained using a batch size smaller than the number of inputs, memory corruption occurs because and indice used to count inputs is used to index a matrix column (batch entry), and goes past the end of the matrix. When the batch size is larger than the number of inputs, no problem seems to occur but the results are likely incorrect.
