### PR TITLE
Check for errors before/after de-/serializing protobufs

### DIFF
--- a/clstm_proto.cc
+++ b/clstm_proto.cc
@@ -191,7 +191,9 @@ void write_as_proto(ostream &output, INetwork *net) {
   unique_ptr<clstm::NetworkProto> proto;
   proto.reset(new clstm::NetworkProto());
   proto_of_net(proto.get(), net);
-  proto->SerializeToOstream(&output);
+  if (proto->SerializeToOstream(&output) == false) {
+    THROW("Serializing failed.");
+  }
 }
 
 void save_as_proto(const string &fname, INetwork *net) {
@@ -205,7 +207,9 @@ Network load_as_proto(const string &fname) {
   stream.open(fname, ios::binary);
   unique_ptr<clstm::NetworkProto> proto;
   proto.reset(new clstm::NetworkProto());
-  proto->ParseFromIstream(&stream);
+  if (proto->ParseFromIstream(&stream) == false) {
+    THROW("Invalid message");
+  }
   return net_of_proto(proto.get());
 }
 }


### PR DESCRIPTION
Right now deserializing  an invalid message and serializing to an unwritable location causes a segmentation fault. This commit instead throws an exception if ParseFromIstream/SerializeToOstream return false.
