### PR TITLE
Use read instead of readsome, which reads 0 bytes on Mac

### DIFF
--- a/clstmocrtrain.cc
+++ b/clstmocrtrain.cc
@@ -54,7 +54,8 @@ string read_text(string fname, int maxsize = 65536) {
   char buf[maxsize];
   buf[maxsize - 1] = 0;
   ifstream stream(fname);
-  int n = stream.readsome(buf, maxsize - 1);
+  stream.read(buf, maxsize - 1);
+  int n = stream.gcount();
   while (n > 0 && buf[n - 1] == '\n') n--;
   return string(buf, n);
 }
@@ -63,7 +64,8 @@ wstring read_text32(string fname, int maxsize = 65536) {
   char buf[maxsize];
   buf[maxsize - 1] = 0;
   ifstream stream(fname);
-  int n = stream.readsome(buf, maxsize - 1);
+  stream.read(buf, maxsize - 1);
+  int n = stream.gcount();
   while (n > 0 && buf[n - 1] == '\n') n--;
   return utf8_to_utf32(string(buf, n));
 }


### PR DESCRIPTION
Since `readsome` is non-blocking and implementation-specific, under OS X it ends up always reading 0 bytes the way it's used here. See e.g.: http://stackoverflow.com/questions/27098420/c-stdistream-readsome-doesnt-read-anything/27098504#27098504

Using `read` and the resulting `gcount` instead should work cross-platform.
