### PR TITLE
fix isnan() error on gcc 5 on ubuntu 16.04 LTS

### DIFF
--- a/batches.cc
+++ b/batches.cc
@@ -76,7 +76,7 @@ bool anynan(TensorMap2 a) {
   for (int j = 0; j < a.dimension(0); j++) {
     for (int k = 0; k < a.dimension(1); k++) {
       float x = a(j, k);
-      if (isnan(x)) return true;
+      if (std::isnan(x)) return true;
     }
   }
   return false;


### PR DESCRIPTION
modify the isnan() to std::isnan() to avoid problem when building clstm on gcc 5 on ubuntu 16.04 LTS
