### PR TITLE
SConstruct: Fix finding custom eigen path

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -85,7 +85,7 @@ if option("eigen", "") == "":
         /usr/local/include/eigen3
         /usr/include/eigen3""".split())
 else:
-    inc = findonpath("Eigen/Eigen", [option("eigen")])
+    inc = findonpath("Eigen/Eigen", [option("eigen", "")])
 
 env.Append(CPPPATH=[inc])
 env.Append(LIBS=["png", "protobuf"])


### PR DESCRIPTION
Fix the following error when using `eigen=...`

```
TypeError: option() takes exactly 2 arguments (1 given):
  File "/home/sandy/code/clstm/SConstruct", line 88:
    inc = findonpath("Eigen/Eigen", [option("eigen")])
```
