### PR TITLE
Fix swig

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -150,7 +150,7 @@ all += [env.Program("test-2d", ["test-2d.cc"], LIBS=[libclstm] + libs)]
 # You can construct the Python extension from scons using the `pyswig` target; however,
 # the recommended way of compiling it is with "python setup.py build"
 
-swigenv = env.Clone(SWIGFLAGS=["-python", "-c++"], SHLIBPREFIX="")
+swigenv = env.Clone()
 swigenv.Tool("swig")
 swigenv.Append(SWIG="3.0")
 swigenv.Append(CPPPATH=[distutils.sysconfig.get_python_inc()])
@@ -158,6 +158,8 @@ pyswig = swigenv.SharedLibrary("_clstm.so",
                                ["clstm.i", "clstm.cc", "clstm_proto.cc", "extras.cc",
                                 "clstm.pb.cc", "clstm_compute.cc",
                                "clstm_prefab.cc", "ctc.cc"],
+                               SWIGFLAGS=['-python', '-c++'],
+                               SHLIBPREFIX="",
                                LIBS=libs)
 Alias('pyswig', [pyswig])
 

--- a/clstm.h
+++ b/clstm.h
@@ -171,7 +171,7 @@ void walk_states(Network net, StateFun f, const string &prefix = "",
 void walk_networks(Network net, NetworkFun f, const string &prefix = "");
 
 // output information about the network (for debugging)
-void network_info(Network net, string prefix = "");
+void network_info(Network net, string prefix);
 void network_detail(Network net, string prefix = "");
 
 // get the number of parameters in a network

--- a/clstmfiltertrain.cc
+++ b/clstmfiltertrain.cc
@@ -88,7 +88,7 @@ int main1(int argc, char **argv) {
     clstm.createBidi(icodec, codec, nhidden);
     clstm.setLearningRate(lrate, momentum);
   }
-  network_info(clstm.net);
+  network_info(clstm.net, "");
 
   int ntrain = getienv("ntrain", 10000000);
   int save_every = getienv("save_every", 10000);

--- a/clstmocrtrain.cc
+++ b/clstmocrtrain.cc
@@ -115,7 +115,7 @@ int main1(int argc, char **argv) {
     clstm.createBidi(codec.codec, getienv("nhidden", 100));
     clstm.setLearningRate(getdenv("lrate", 1e-4), getdenv("momentum", 0.9));
   }
-  network_info(clstm.net);
+  network_info(clstm.net, "");
 
   double test_error = 9999.0;
   double best_error = 1e38;


### PR DESCRIPTION
Making the header definition and implementation of `network_info` makes the SWIG bindings compile. I do not grasp the consequences though.
