### PR TITLE
test-batchlstm: Add missing include file

### DIFF
--- a/test-batchlstm.cc
+++ b/test-batchlstm.cc
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <unistd.h>     // unlink
 #include <vector>
 #include "clstm.h"
 #include "extras.h"


### PR DESCRIPTION
Fix an compilation error:

test-batchlstm.cc: In function 'int main(int, char**)':
test-batchlstm.cc:111:27: error: 'unlink' was not declared in this scope
   unlink("**test0**.clstm");
                           ^

Signed-off-by: Stefan Weil sw@weilnetz.de
