### PR TITLE
Use input size of loaded net as target_height.

### DIFF
--- a/clstmhl.h
+++ b/clstmhl.h
@@ -161,6 +161,7 @@ struct CLSTMOCR {
       return false;
     }
     nclasses = net->codec.size();
+    target_height = net->ninput();
     normalizer.reset(make_CenterNormalizer());
     normalizer->target_height = target_height;
     return true;


### PR DESCRIPTION
While loading the net in particular its input size is determined.
The target_height of the CLSTMOCR and thus of the normalizer was not
adjusted and remained at the initial value of 48.
This resulted in firing assertions.

Now target_height is set to the input size of the loaded net.