### PR TITLE
Fixed return value out-of-order with what the calling function expect…

### DIFF
--- a/clstmocrtrain.cc
+++ b/clstmocrtrain.cc
@@ -85,7 +85,7 @@ pair<double, double> test_set_error(CLSTMOCR &clstm, Dataset &testset) {
     count += gt.size();
     errors += levenshtein(pred, gt);
   }
-  return make_pair(count, errors);
+  return make_pair(errors, count);
 }
 
 int print_usage(char **argv) {


### PR DESCRIPTION
…s. Which causes wrong error rate calculation.