### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ available now.
  - Optional: HDF5, ZMQ, Python
 
 ```sh
-# Ubuntu 15.04 / Debian 8
-sudo apt-get install scons libprotobuf-dev libprotobuf9 protobuf-compiler libpng-dev libeigen3-dev swig
-
 # Ubuntu 16.04
 sudo apt-get install scons libprotobuf-dev libprotobuf9v5 protobuf-compiler libpng-dev libeigen3-dev swig
+
+# Ubuntu 15.04 / Debian 8
+sudo apt-get install scons libprotobuf-dev libprotobuf9 protobuf-compiler libpng-dev libeigen3-dev swig
 
 # Ubuntu 14.04:
 sudo apt-get install scons libprotobuf-dev libprotobuf8 protobuf-compiler libpng-dev swig

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ available now.
 # Ubuntu 15.04 / Debian 8
 sudo apt-get install scons libprotobuf-dev libprotobuf9 protobuf-compiler libpng-dev libeigen3-dev swig
 
+# Ubuntu 16.04
+sudo apt-get install scons libprotobuf-dev libprotobuf9v5 protobuf-compiler libpng-dev libeigen3-dev swig
+
 # Ubuntu 14.04:
 sudo apt-get install scons libprotobuf-dev libprotobuf8 protobuf-compiler libpng-dev swig
 ```


### PR DESCRIPTION
libprotobuf9 has been replaced by libprotobuf9v5 in Ubuntu 16.04