### PR TITLE
Add missing return statements to the print_usage function

### DIFF
--- a/clstmocr.cc
+++ b/clstmocr.cc
@@ -50,6 +50,7 @@ int print_usage(char **argv) {
     cerr << "     conf          Output character-wise predictions. Default: 0\n";
     cerr << "     output        Output format, either 'text' or 'posteriors'. Default: 'text'\n";
     cerr << "     save_text     Save text to IMAGEFILE.txt. Default: 1\n";
+    return EXIT_FAILURE;
 }
 
 int main1(int argc, char **argv) {

--- a/clstmocrtrain.cc
+++ b/clstmocrtrain.cc
@@ -113,6 +113,7 @@ int print_usage(char **argv) {
     cerr << "     display_every   Update display every n-th iteration. Requires compilation\n";
     cerr << "                     with 'scons display=1'. Default: 0\n";
     cerr << "     params          Whether to report variable values on read. Default: 1\n";
+    return EXIT_FAILURE;
 }
 
 int main1(int argc, char **argv) {


### PR DESCRIPTION
This fixes errors reported by LGTM:

    Function print_usage should return a value of type int
    but does not return a value here

Signed-off-by: Stefan Weil <sw@weilnetz.de>